### PR TITLE
Fixing type in variable in IbusInterface.js

### DIFF
--- a/src/IbusInterface.js
+++ b/src/IbusInterface.js
@@ -34,7 +34,7 @@ var IbusInterface = function(devicePath) {
     function initIBUS() {
         serialPort = new SerialPort(device, {
             autoOpen: false,
-            baudrate: 9600,
+            baudRate: 9600,
             parity: 'even',
             stopbits: 1,
             databits: 8,


### PR DESCRIPTION
Nodejs 'serial' module expects variable as baudRate not baudrate. This fixes the issue.